### PR TITLE
Fix profile level for journald-write-to-persistent-disk-cos

### DIFF
--- a/configs/defs/cos.textproto
+++ b/configs/defs/cos.textproto
@@ -2629,7 +2629,7 @@ benchmark_configs: {
       "cannot be used to make these changes persistent across reboots. The "
       "steps mentioned above needs to be performed after every boot."
     cis_benchmark: {
-      profile_level: 2
+      profile_level: 1
       severity: LOW
     }
     scan_instructions:


### PR DESCRIPTION
COS benchmark journald-write-to-persistent-disk-cos maps to CIS 4.1.2.2 Ensure journald is configured to write logfiles to persistent disk (Automated), which is suppose to be Level 1 requirement.
