### PR TITLE
Generic linux SSH checks

### DIFF
--- a/configs/defs/generic_linux.textproto
+++ b/configs/defs/generic_linux.textproto
@@ -9561,6 +9561,7 @@ benchmark_configs: {
 benchmark_configs: {
   id: "ensure-sshd-ciphers-configured"
   compliance_note: {
+    version: { cpe_uri: "fallback" version: "2.0.0" benchmark_document: "CIS Distribution Independent Linux" }
     title: "Ensure sshd Ciphers are configured"
     description: 
       "This variable limits the ciphers that SSH can use during communication. The only strong ciphers currently FIPS 140 "
@@ -9618,6 +9619,7 @@ benchmark_configs: {
 benchmark_configs: {
   id: "ensure-sshd-clientalive-configured"
   compliance_note: {
+    version: { cpe_uri: "fallback" version: "2.0.0" benchmark_document: "CIS Distribution Independent Linux" }
     title: "Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured"
     description:
       "The two options ClientAliveInterval and ClientAliveCountMax control the timeout "
@@ -9702,6 +9704,7 @@ benchmark_configs: {
 benchmark_configs: {
   id: "ssh-maxsessions-10-or-less"
   compliance_note: {
+    version: { cpe_uri: "fallback" version: "2.0.0" benchmark_document: "CIS Distribution Independent Linux" }
     title: "Ensure SSH MaxSessions is set to 10 or less"
     description:
       "The MaxSessions parameter specifies the maximum number of open "
@@ -9747,6 +9750,7 @@ benchmark_configs: {
 benchmark_configs: {
   id: "sshd-access-configured"
   compliance_note: {
+    version: { cpe_uri: "fallback" version: "2.0.0" benchmark_document: "CIS Distribution Independent Linux" }
     title: "Ensure sshd access is configured"
     description:
       "There are several options available to limit which users and groups can access the "
@@ -9796,6 +9800,7 @@ benchmark_configs: {
 benchmark_configs: {
   id: "sshd-banner-configured"
   compliance_note: {
+    version: { cpe_uri: "fallback" version: "2.0.0" benchmark_document: "CIS Distribution Independent Linux" }
     title: "Ensure sshd Banner is configured"
     description:
       "The Banner parameter specifies a file whose contents must be sent to the remote user "
@@ -9838,6 +9843,7 @@ benchmark_configs: {
 benchmark_configs: {
   id: "sshd-disable-forwarding-configured"
   compliance_note: {
+    version: { cpe_uri: "fallback" version: "2.0.0" benchmark_document: "CIS Distribution Independent Linux" }
     title: "Ensure sshd DisableForwarding is enabled"
     description:
       "The DisableForwarding parameter disables all forwarding features, including X11, ssh-agent, TCP, and StreamLocal forwarding. "
@@ -9879,6 +9885,7 @@ benchmark_configs: {
 benchmark_configs: {
   id: "sshd-gssapi-authentication-disabled"
   compliance_note: {
+    version: { cpe_uri: "fallback" version: "2.0.0" benchmark_document: "CIS Distribution Independent Linux" }
     title: "Ensure sshd GSSAPIAuthentication is disabled"
     description:
       "The GSSAPIAuthentication parameter specifies whether user authentication "
@@ -9920,6 +9927,7 @@ benchmark_configs: {
 benchmark_configs: {
   id: "sshd-hostbasedauthentication-disabled"
   compliance_note: {
+    version: { cpe_uri: "fallback" version: "2.0.0" benchmark_document: "CIS Distribution Independent Linux" }
     title: "Ensure SSH HostbasedAuthentication is disabled"
     description:
       "The HostbasedAuthentication parameter specifies if authentication is allowed through "


### PR DESCRIPTION
This is part of a series of multiple PRs to lay the ground for following separate PR for [Ubuntu 22.04](https://github.com/SN-Eros/localtoast/tree/ubuntu_22), [Debian 12](https://github.com/SN-Eros/localtoast/tree/linux_debian_12) and additional features ([software version compare](https://github.com/SN-Eros/localtoast/tree/sw-version-compare) for installed package version, and [shell wildcard](https://github.com/SN-Eros/localtoast/tree/shell-wildcard) to check user's shell).

This PR introduces new benchmarks focusing on the SSH daemon and client configuration.